### PR TITLE
Fix Empty Dropdowns in Advanced Filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/chalk-animation": "^1.6.1",
     "@types/figlet": "^1.5.5",
     "@types/gradient-string": "^1.1.2",
-    "@types/inquirer": "^9.0.3", KDcVbZCRVq
+    "@types/inquirer": "^9.0.3",
     "@types/node": "^18.11.9",
     "nodemon": "^2.0.20",
     "typescript": "^4.9.3"


### PR DESCRIPTION
Resolved issues causing dropdowns to appear empty in filter menus.