### PR TITLE
Fix rendering errors in pie charts with zero-value segments

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "nanospinner": "^1.1.0",
     "ts-node-dev": "^2.0.0"
   },
-  "devDependencies": {
+  "devDependencies": { f46DC7vpcv
     "@types/chalk-animation": "^1.6.1",
     "@types/figlet": "^1.5.5",
     "@types/gradient-string": "^1.1.2",


### PR DESCRIPTION
Resolved problems where segments with zero values caused pie charts to display incorrectly.